### PR TITLE
Fix: add Staking Package linking to fix MPL_BUBBLEGUM Dependency inst…

### DIFF
--- a/.github/actions/publish-sdk/action.yml
+++ b/.github/actions/publish-sdk/action.yml
@@ -14,6 +14,11 @@ runs:
       working-directory: ${{ inputs.working_dir }}
       shell: bash
 
+    - name: Link staking package
+      run: cd ./packages/hpl-nectar-staking && yarn link && cd ../.. && yarn link @honeycomb-protocol/nectar-staking
+      working-directory: ${{ inputs.working_dir }}
+      shell: bash
+
     - name: Compile TypeScript
       run: yarn tsc
       working-directory: ${{ inputs.working_dir }}


### PR DESCRIPTION
this PR fixes MPL_BUBBLEGUM Dependency install issues in SDK Publish by adding Staking Package linking in WorkFlow Actions